### PR TITLE
Avoid non-zero exit on any normal run through. Rely on "--raise" flag…

### DIFF
--- a/lib/mix/tasks/doctor.ex
+++ b/lib/mix/tasks/doctor.ex
@@ -90,7 +90,7 @@ defmodule Mix.Tasks.Doctor do
 
     unless result do
       System.at_exit(fn _ ->
-        exit({:shutdown, 1})
+        exit({:shutdown, 0})
       end)
 
       if config.raise do
@@ -114,7 +114,7 @@ defmodule Mix.Tasks.Doctor do
           Mix.raise("Doctor validation has failed and raised an error")
         end
 
-        exit({:shutdown, 1})
+        exit({:shutdown, 0})
       end
     end)
 


### PR DESCRIPTION
Currently, if you run the `mix doctor` command it always exits with a non-zero. To allow the CI to continue to run successfully, don't exit like that and only raise an error if we pass the flag `--raise`